### PR TITLE
Remove warnings about isneutral=None in stage 3

### DIFF
--- a/ltfa/__init__.py
+++ b/ltfa/__init__.py
@@ -51,7 +51,7 @@ def run(args) -> None:
     for a in accounts:
         a.stage2(accounts)
 
-    # Stage 3 (perform some txn classifications based on now-complete knowledge)
+    # Stage 3 (finalization based on now-complete knowledge)
     for a in accounts:
         a.stage3()
 

--- a/ltfa/account.py
+++ b/ltfa/account.py
@@ -53,26 +53,10 @@ class Account:
             stillnegative = t.balance < 0
 
     def stage3(self) -> None:
-        """ This is basically a transaction classification step. """
-        self._classify_txns()
-
-    def _classify_txns(self) -> None:
         for txn in self.txns:
-            # Any txn still with isneutral==None is now assumed non-neutral:
+            # Any txn still with isneutral==None can now be safely assumed non-neutral.
             if txn.isneutral == None:
                 txn.isneutral = False
-            if isinstance(txn.peeraccount, Account):
-                if not txn.isneutral:
-                    logging.info(
-                        "{}: Weird txn as an Account as peeraccount but isn't neutral: {}".format(
-                            self.name, txn.shortstr()
-                        )
-                    )
-            else:
-                if txn.isneutral:
-                    logging.info(
-                        "{}: Weird txn is neutral doesn't point to an Account: {}".format(self.name, txn.shortstr())
-                    )
 
     def _recompute_balances(self) -> None:
         balance_start = self.config.get('balance_start') or 0

--- a/tests/scenarios/savings_negative_gains/savings_negative_gains.log
+++ b/tests/scenarios/savings_negative_gains/savings_negative_gains.log
@@ -1,2 +1,1 @@
-INFO: SomeSavingsAcc: Weird txn is neutral doesn't point to an Account: 2010-12-31, € 1000.0
 INFO: SomeSavingsAcc: Final balance after 21 txns: 2030-12-31, € 1082.94

--- a/tests/scenarios/savings_varying_interest/savings_varying_interest.log
+++ b/tests/scenarios/savings_varying_interest/savings_varying_interest.log
@@ -1,2 +1,1 @@
-INFO: SomeSavingsAcc: Weird txn is neutral doesn't point to an Account: 2010-12-31, € 1000.0
 INFO: SomeSavingsAcc: Final balance after 31 txns: 2040-12-31, € 5150.15

--- a/tests/scenarios/simple_savings/simple_savings.log
+++ b/tests/scenarios/simple_savings/simple_savings.log
@@ -1,2 +1,1 @@
-INFO: SomeSavingsAcc: Weird txn is neutral doesn't point to an Account: 2010-12-31, € 1000.0
 INFO: SomeSavingsAcc: Final balance after 11 txns: 2020-12-31, € 1628.89

--- a/tests/scenarios/simple_savings_monthly/simple_savings_monthly.log
+++ b/tests/scenarios/simple_savings_monthly/simple_savings_monthly.log
@@ -1,2 +1,1 @@
-INFO: SomeSavingsAcc: Weird txn is neutral doesn't point to an Account: 2009-12-01, € 1000.0
 INFO: SomeSavingsAcc: Final balance after 121 txns: 2019-12-01, € 1647.01


### PR DESCRIPTION
This is perfectly valid, caused by transactions specified in the configuration.