### PR TITLE
Add boundary scenario for gains calculation

### DIFF
--- a/tests/scenarios/first_txn_is_gain/first_txn_is_gain.conf
+++ b/tests/scenarios/first_txn_is_gain/first_txn_is_gain.conf
@@ -1,0 +1,44 @@
+---
+# This is a regression test for a bug in capgain gains analysis. Due to the
+# approach with cumsum().interpolate().diff() to smoothen out the gains, there
+# was the problem of the very first gain in an account being ignoring in the
+# returns calculation if it was also the very first transaction in that
+# account.
+#
+# We cover two scenarios here: A gain being the very first transaction overall,
+# and a gain being the very first transaction of a particular account.
+accounts:
+  - name: "FirstTxnIsGainAndVeryFirstTxn"
+    active: true
+    asset-type: investment
+    transactions:
+      # Expected outcome: The initial txn accounts for a 1k gain. How it factors
+      # into the returns calculation is a bit of a wild card, but it definitely
+      # should not be completely discarded from the total gains.
+      - {date: 2010-01-01, value: '1000.0', isneutral: false}
+      - {date: 2014-01-02, value: '-7000.0', isneutral: true}
+      - {date: 2015-01-02, value: '-1000.0', isneutral: true}
+    balances:
+      - {date: 2011-01-01, balance: '1000.0'}
+      - {date: 2012-01-01, balance: '2000.0'}
+      - {date: 2013-01-01, balance: '4000.0'}
+      - {date: 2014-01-01, balance: '8000.0'}
+
+
+  - name: "FirstTxnIsGain"
+    active: true
+    asset-type: investment
+    transactions:
+      # During 2013, the invested amount is 1000 (lingering on the other
+      # account), so while these 1000 are an "infinite return" for *this*
+      # account, it should be considered a 100% return overall for 2013.
+      - {date: 2015-01-01, value: '1000.0', isneutral: false}
+    balances:
+      - {date: 2016-01-01, balance: '2000.0'}
+      - {date: 2017-01-01, balance: '4000.0'}
+      - {date: 2018-01-01, balance: '8000.0'}
+
+# Expected total gains:
+# 500 + 500 + 1000 + 2000 + 4000 + 1000 + 1000 + 2000 + 4000 = 16000 (not 15000!)
+
+# vim:ft=yaml

--- a/tests/scenarios/first_txn_is_gain/first_txn_is_gain.investment_report.txt
+++ b/tests/scenarios/first_txn_is_gain/first_txn_is_gain.investment_report.txt
@@ -1,0 +1,26 @@
+8y ewm:
+	invested     = 2329 €
+	gains p.a.   = 2276 €
+	returns p.a. = 97.72%
+4y ewm:
+	invested     = 2650 €
+	gains p.a.   = 2628 €
+	returns p.a. = 99.14%
+2y ewm:
+	invested     = 3183 €
+	gains p.a.   = 3167 €
+	returns p.a. = 99.51%
+Statistics over all time (8 years):
+	Avg. invested amount: 2005 €
+	Total capital gains: 15000 €
+	Avg. capital gains (p.a.): 1873 €
+	Avg. returns (p.a.): 93.43%
+Return rate in 2010:  0.00% (0 € gains on 1000 € invested)
+Return rate in 2011: 99.73% (997 € gains on 1000 € invested)
+Return rate in 2012: 99.86% (1997 € gains on 2000 € invested)
+Return rate in 2013: 99.86% (3995 € gains on 4000 € invested)
+Return rate in 2014: 98.92% (1008 € gains on 1019 € invested)
+Return rate in 2015: 99.73% (1000 € gains on 1003 € invested)
+Return rate in 2016: 99.86% (1997 € gains on 2000 € invested)
+Return rate in 2017: 99.86% (3995 € gains on 4000 € invested)
+Return rate past 1y: 99.73% (4000 € gains on 4011 € invested)

--- a/tests/scenarios/first_txn_is_gain/first_txn_is_gain.log
+++ b/tests/scenarios/first_txn_is_gain/first_txn_is_gain.log
@@ -1,0 +1,2 @@
+INFO: FirstTxnIsGainAndVeryFirstTxn: Final balance after 7 txns: 2015-01-02, € 0.0
+INFO: FirstTxnIsGain: Final balance after 4 txns: 2018-01-01, € 8000.0

--- a/tests/test_ltfa.py
+++ b/tests/test_ltfa.py
@@ -12,6 +12,7 @@ import ltfa.util
 @pytest.mark.parametrize(
     'scenario',
     (
+        'first_txn_is_gain',
         'savings_negative_gains',
         'savings_varying_interest',
         'shared_ownership',


### PR DESCRIPTION
Our current behavior is _not_ correct. For now, the test simply illustrates the bug. Adding it nevertheless will help make the effects of the bug fix (hopefully coming soon) more explicit.