### PR TITLE
Run gains analysis on per-account basis

### DIFF
--- a/ltfa/plotting_bokeh.py
+++ b/ltfa/plotting_bokeh.py
@@ -321,8 +321,6 @@ def add_capital_returns_plot(figure, accounts, annotations, analysis) -> None:
     for years in ewm_years:
         df[f'returns_ewm_{years}'] = analysis.get_averaged_capgains(ewm_span_years=years).returns.returns
 
-    df = df[df.index >= analysis.date_of_first_actual_gain]
-
     cds = bk.models.ColumnDataSource(df)
     returnsplotter = functools.partial(plotreturns, figure, cds, line_width=1.3, color='green')
 

--- a/tests/scenarios/first_txn_in_account_is_gain/first_txn_in_account_is_gain.investment_report.txt
+++ b/tests/scenarios/first_txn_in_account_is_gain/first_txn_in_account_is_gain.investment_report.txt
@@ -1,21 +1,21 @@
 8y ewm:
 	invested     = 1758 €
-	gains p.a.   = 264 €
-	returns p.a. = 15.03%
+	gains p.a.   = 297 €
+	returns p.a. = 16.90%
 4y ewm:
 	invested     = 1827 €
-	gains p.a.   = 196 €
-	returns p.a. = 10.74%
+	gains p.a.   = 247 €
+	returns p.a. = 13.49%
 2y ewm:
 	invested     = 1926 €
-	gains p.a.   = 100 €
-	returns p.a. = 5.19%
+	gains p.a.   = 152 €
+	returns p.a. = 7.90%
 Statistics over all time (3 years):
 	Avg. invested amount: 1677 €
 	Total capital gains: 1030 €
 	Avg. capital gains (p.a.): 343 €
 	Avg. returns (p.a.): 20.45%
-Return rate in 2009: 100.72% (1007 € gains on 1000 € invested)
-Return rate in 2010:   0.63% (13 € gains on 2010 € invested)
-Return rate in 2011:   0.50% (10 € gains on 2020 € invested)
-Return rate past 1y:   0.50% (10 € gains on 2020 € invested)
+Return rate in 2009:  1.00% (10 € gains on 1000 € invested)
+Return rate in 2010: 50.25% (1010 € gains on 2010 € invested)
+Return rate in 2011:  0.50% (10 € gains on 2020 € invested)
+Return rate past 1y:  0.50% (10 € gains on 2020 € invested)

--- a/tests/scenarios/simple_savings_5p_with_noise/simple_savings_5p_with_noise.investment_report.txt
+++ b/tests/scenarios/simple_savings_5p_with_noise/simple_savings_5p_with_noise.investment_report.txt
@@ -1,27 +1,27 @@
 8y ewm:
 	invested     = 1375 €
-	gains p.a.   = 78 €
-	returns p.a. = 5.64%
+	gains p.a.   = 69 €
+	returns p.a. = 4.99%
 4y ewm:
 	invested     = 1449 €
-	gains p.a.   = 92 €
-	returns p.a. = 6.34%
+	gains p.a.   = 72 €
+	returns p.a. = 4.99%
 2y ewm:
 	invested     = 1510 €
-	gains p.a.   = 119 €
-	returns p.a. = 7.88%
+	gains p.a.   = 75 €
+	returns p.a. = 4.99%
 Statistics over all time (10 years):
 	Avg. invested amount: 1258 €
 	Total capital gains: 629 €
 	Avg. capital gains (p.a.): 63 €
 	Avg. returns (p.a.): 4.99%
-Return rate in 2011: 4.82% (50 € gains on 1038 € invested)
-Return rate in 2012: 4.82% (53 € gains on 1090 € invested)
-Return rate in 2013: 4.82% (55 € gains on 1144 € invested)
-Return rate in 2014: 4.82% (58 € gains on 1201 € invested)
-Return rate in 2015: 4.82% (61 € gains on 1261 € invested)
-Return rate in 2016: 4.82% (64 € gains on 1324 € invested)
-Return rate in 2017: 4.82% (67 € gains on 1391 € invested)
-Return rate in 2018: 4.82% (70 € gains on 1460 € invested)
-Return rate in 2019: 4.82% (74 € gains on 1533 € invested)
+Return rate in 2011: 4.99% (52 € gains on 1038 € invested)
+Return rate in 2012: 5.01% (55 € gains on 1090 € invested)
+Return rate in 2013: 5.00% (57 € gains on 1144 € invested)
+Return rate in 2014: 5.00% (60 € gains on 1201 € invested)
+Return rate in 2015: 4.99% (63 € gains on 1261 € invested)
+Return rate in 2016: 5.01% (66 € gains on 1324 € invested)
+Return rate in 2017: 5.00% (70 € gains on 1391 € invested)
+Return rate in 2018: 5.00% (73 € gains on 1460 € invested)
+Return rate in 2019: 4.99% (76 € gains on 1533 € invested)
 Return rate past 1y: 5.00% (78 € gains on 1552 € invested)


### PR DESCRIPTION
This fixes the calculation error that used to occur when non-neutral
investment transactions (= gains) were not all cleanly distributed over
time, which they aren't in practice (see test scenario
simple_savings_5p_with_noise).

For example, if two accounts had yearly gains, one on Jan 1 and the
other on Jan 3, our interpolation between gains would spread out the Jan 1
gain over 363 days the Jan 3 over just the two days in-between. As far
as total as concerned, this is not strictly wrong. But it distorts the
ranged calculations (like per-year and ewm stats) and plotting of past gains.

On real-world data, this change results in slight shifts in the per-year
and ewm analysis results and plots, which is to be expected. The totals
(gains, invested amounts, returns) are completely unaffected.

Note that this change also removes the plotting truncating at
date_of_first_actual_gain because we're not starting the gains DataFrame
at the "beginning of time" anymore, but exactly where each investment
account has its first non-zero balance. This way, there should be no
"settling down" artifacts that would need to be compensated.