### PR TITLE
Fix lost gain if it is the first transaction

### DIFF
--- a/ltfa/analysis.py
+++ b/ltfa/analysis.py
@@ -166,7 +166,13 @@ class Analysis():
         # early in the pipeline, which can distort our calculations of the invested
         # amount. Just distributing the gains like this appears to be the only way
         # to get useful EWMH plots out of the data.
-        gains = gains.cumsum().interpolate(method='time').diff()
+        gains_redistributed = gains.cumsum().interpolate().diff()
+
+        # Calling diff() inherently discards the very first value (sets it to
+        # zero), but it's still a gain that needs to be included, so we restore
+        # it manually here:
+        gains_redistributed.iloc[0] = gains.iloc[0]
+        gains = gains_redistributed
 
         # Daily balance of invested money (total on that day)
         self.totalinvest = totalinvest

--- a/tests/scenarios/first_txn_overall_is_gain/first_txn_overall_is_gain.investment_report.txt
+++ b/tests/scenarios/first_txn_overall_is_gain/first_txn_overall_is_gain.investment_report.txt
@@ -1,22 +1,22 @@
 8y ewm:
 	invested     = 2329 €
-	gains p.a.   = 2155 €
-	returns p.a. = 92.54%
+	gains p.a.   = 2300 €
+	returns p.a. = 98.78%
 4y ewm:
 	invested     = 2650 €
-	gains p.a.   = 2538 €
-	returns p.a. = 95.78%
+	gains p.a.   = 2616 €
+	returns p.a. = 98.72%
 2y ewm:
 	invested     = 3182 €
-	gains p.a.   = 3135 €
-	returns p.a. = 98.53%
+	gains p.a.   = 3154 €
+	returns p.a. = 99.11%
 Statistics over all time (4 years):
 	Avg. invested amount: 2004 €
-	Total capital gains: 7000 €
-	Avg. capital gains (p.a.): 1748 €
-	Avg. returns (p.a.): 87.20%
-Return rate in 2010:  0.00% (0 € gains on 1000 € invested)
-Return rate in 2011: 99.73% (997 € gains on 1000 € invested)
-Return rate in 2012: 99.86% (1997 € gains on 2000 € invested)
-Return rate in 2013: 99.86% (3995 € gains on 4000 € invested)
-Return rate past 1y: 99.73% (4000 € gains on 4011 € invested)
+	Total capital gains: 8000 €
+	Avg. capital gains (p.a.): 1997 €
+	Avg. returns (p.a.): 99.66%
+Return rate in 2010: 100.00% (1000 € gains on 1000 € invested)
+Return rate in 2011:  99.73% (997 € gains on 1000 € invested)
+Return rate in 2012:  99.86% (1997 € gains on 2000 € invested)
+Return rate in 2013:  99.86% (3995 € gains on 4000 € invested)
+Return rate past 1y:  99.73% (4000 € gains on 4011 € invested)


### PR DESCRIPTION
This has no effect on the report with my real-world data (only because the issue doesn't appear there).

The most important effect on the first_txn_overall_is_gain scenario is that the total gains are now correct (8k instead of 7k).