### PR TITLE
Take leap years into account for average capgains

### DIFF
--- a/tests/scenarios/first_txn_overall_is_gain/first_txn_overall_is_gain.investment_report.txt
+++ b/tests/scenarios/first_txn_overall_is_gain/first_txn_overall_is_gain.investment_report.txt
@@ -1,20 +1,20 @@
 8y ewm:
 	invested     = 2329 €
-	gains p.a.   = 2300 €
-	returns p.a. = 98.78%
+	gains p.a.   = 2302 €
+	returns p.a. = 98.85%
 4y ewm:
 	invested     = 2650 €
-	gains p.a.   = 2616 €
-	returns p.a. = 98.72%
+	gains p.a.   = 2618 €
+	returns p.a. = 98.80%
 2y ewm:
 	invested     = 3182 €
-	gains p.a.   = 3154 €
-	returns p.a. = 99.11%
+	gains p.a.   = 3156 €
+	returns p.a. = 99.17%
 Statistics over all time (4 years):
 	Avg. invested amount: 2004 €
 	Total capital gains: 8000 €
-	Avg. capital gains (p.a.): 1997 €
-	Avg. returns (p.a.): 99.66%
+	Avg. capital gains (p.a.): 1999 €
+	Avg. returns (p.a.): 99.73%
 Return rate in 2010: 100.00% (1000 € gains on 1000 € invested)
 Return rate in 2011:  99.73% (997 € gains on 1000 € invested)
 Return rate in 2012:  99.86% (1997 € gains on 2000 € invested)

--- a/tests/scenarios/savings_varying_interest/savings_varying_interest.investment_report.txt
+++ b/tests/scenarios/savings_varying_interest/savings_varying_interest.investment_report.txt
@@ -5,7 +5,7 @@
 4y ewm:
 	invested     = 4897 €
 	gains p.a.   = 100 €
-	returns p.a. = 2.03%
+	returns p.a. = 2.04%
 2y ewm:
 	invested     = 4993 €
 	gains p.a.   = 100 €

--- a/tests/scenarios/simple_savings_100p/simple_savings_100p.investment_report.txt
+++ b/tests/scenarios/simple_savings_100p/simple_savings_100p.investment_report.txt
@@ -1,20 +1,20 @@
 8y ewm:
 	invested     = 202653 €
-	gains p.a.   = 202008 €
-	returns p.a. = 99.68%
+	gains p.a.   = 202094 €
+	returns p.a. = 99.72%
 4y ewm:
 	invested     = 292116 €
-	gains p.a.   = 291088 €
-	returns p.a. = 99.65%
+	gains p.a.   = 291169 €
+	returns p.a. = 99.68%
 2y ewm:
 	invested     = 398332 €
-	gains p.a.   = 396610 €
-	returns p.a. = 99.57%
+	gains p.a.   = 396648 €
+	returns p.a. = 99.58%
 Statistics over all time (10 years):
 	Avg. invested amount: 102515 €
 	Total capital gains: 1023000 €
-	Avg. capital gains (p.a.): 102216 €
-	Avg. returns (p.a.): 99.71%
+	Avg. capital gains (p.a.): 102272 €
+	Avg. returns (p.a.): 99.76%
 Return rate in 2010: 99.73% (997 € gains on 1000 € invested)
 Return rate in 2011: 99.86% (1997 € gains on 2000 € invested)
 Return rate in 2012: 99.86% (3995 € gains on 4000 € invested)

--- a/tests/scenarios/simple_savings_5p_payout_dec31/simple_savings_5p_payout_dec31.investment_report.txt
+++ b/tests/scenarios/simple_savings_5p_payout_dec31/simple_savings_5p_payout_dec31.investment_report.txt
@@ -1,20 +1,20 @@
 8y ewm:
 	invested     = 1375 €
 	gains p.a.   = 69 €
-	returns p.a. = 4.99%
+	returns p.a. = 5.00%
 4y ewm:
 	invested     = 1449 €
 	gains p.a.   = 72 €
-	returns p.a. = 4.99%
+	returns p.a. = 5.00%
 2y ewm:
 	invested     = 1510 €
 	gains p.a.   = 75 €
-	returns p.a. = 4.99%
+	returns p.a. = 5.00%
 Statistics over all time (10 years):
 	Avg. invested amount: 1258 €
 	Total capital gains: 629 €
 	Avg. capital gains (p.a.): 63 €
-	Avg. returns (p.a.): 4.99%
+	Avg. returns (p.a.): 5.00%
 Return rate in 2011: 5.00% (50 € gains on 1000 € invested)
 Return rate in 2012: 5.00% (52 € gains on 1050 € invested)
 Return rate in 2013: 5.00% (55 € gains on 1103 € invested)

--- a/tests/scenarios/simple_savings_5p_payout_feb28/simple_savings_5p_payout_feb28.investment_report.txt
+++ b/tests/scenarios/simple_savings_5p_payout_feb28/simple_savings_5p_payout_feb28.investment_report.txt
@@ -8,7 +8,7 @@
 	returns p.a. = 5.00%
 2y ewm:
 	invested     = 1510 €
-	gains p.a.   = 75 €
+	gains p.a.   = 76 €
 	returns p.a. = 5.00%
 Statistics over all time (10 years):
 	Avg. invested amount: 1258 €

--- a/tests/scenarios/simple_savings_5p_payout_march31/simple_savings_5p_payout_march31.investment_report.txt
+++ b/tests/scenarios/simple_savings_5p_payout_march31/simple_savings_5p_payout_march31.investment_report.txt
@@ -1,11 +1,11 @@
 8y ewm:
 	invested     = 1375 €
 	gains p.a.   = 69 €
-	returns p.a. = 4.99%
+	returns p.a. = 5.00%
 4y ewm:
 	invested     = 1449 €
 	gains p.a.   = 72 €
-	returns p.a. = 4.99%
+	returns p.a. = 5.00%
 2y ewm:
 	invested     = 1510 €
 	gains p.a.   = 75 €
@@ -14,7 +14,7 @@ Statistics over all time (10 years):
 	Avg. invested amount: 1258 €
 	Total capital gains: 629 €
 	Avg. capital gains (p.a.): 63 €
-	Avg. returns (p.a.): 4.99%
+	Avg. returns (p.a.): 5.00%
 Return rate in 2011: 4.99% (52 € gains on 1038 € invested)
 Return rate in 2012: 5.01% (55 € gains on 1090 € invested)
 Return rate in 2013: 5.00% (57 € gains on 1144 € invested)

--- a/tests/scenarios/simple_savings_5p_with_noise/simple_savings_5p_with_noise.investment_report.txt
+++ b/tests/scenarios/simple_savings_5p_with_noise/simple_savings_5p_with_noise.investment_report.txt
@@ -1,11 +1,11 @@
 8y ewm:
 	invested     = 1375 €
 	gains p.a.   = 69 €
-	returns p.a. = 4.99%
+	returns p.a. = 5.00%
 4y ewm:
 	invested     = 1449 €
 	gains p.a.   = 72 €
-	returns p.a. = 4.99%
+	returns p.a. = 5.00%
 2y ewm:
 	invested     = 1510 €
 	gains p.a.   = 75 €
@@ -14,7 +14,7 @@ Statistics over all time (10 years):
 	Avg. invested amount: 1258 €
 	Total capital gains: 629 €
 	Avg. capital gains (p.a.): 63 €
-	Avg. returns (p.a.): 4.99%
+	Avg. returns (p.a.): 5.00%
 Return rate in 2011: 4.99% (52 € gains on 1038 € invested)
 Return rate in 2012: 5.01% (55 € gains on 1090 € invested)
 Return rate in 2013: 5.00% (57 € gains on 1144 € invested)


### PR DESCRIPTION
This change has slight effects (in the right direction) for the scenario results. On real data, it shifts the overall average by just one basis point.