### PR TITLE
Remove docker/hadolint orb from pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,4 @@ workflows:
     jobs:
       - build-and-test
       - check-single-commit
-      - docker/hadolint:
-          dockerfiles: Dockerfile
       - shellcheck/check


### PR DESCRIPTION
Apparently, the orb doesn't exist anymore?