### PR TITLE
Remove mypy from CI pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,6 @@ jobs:
       - run:
           name: Run tests
           command: pipenv run pytest
-      - run:
-          name: Run mypy
-          command: pipenv run mypy --ignore-missing-imports ltfa
 
   check-single-commit:
     docker:


### PR DESCRIPTION
Fails due to multiple issues in bokeh, one of them being https://github.com/bokeh/bokeh/issues/14412, I suppose. Will try pyright instead.